### PR TITLE
Support multiple tags

### DIFF
--- a/__tests__/fixtures/queries/p.graphql
+++ b/__tests__/fixtures/queries/p.graphql
@@ -9,6 +9,9 @@ query {
       userByReviewedBy {
         name
       }
+      userByPublishedBy {
+        name
+      }
     }
   }
 }

--- a/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -8,6 +8,7 @@ Object {
         Object {
           "body": "Best way to learn postgraphile is using it",
           "headline": "Learning Postgraphile",
+          "userByPublishedBy": null,
           "userByReviewedBy": null,
           "userByUserId": Object {
             "name": "Michael",

--- a/__tests__/p-schema.sql
+++ b/__tests__/p-schema.sql
@@ -14,10 +14,11 @@ create table p.post (
   headline                  text,
   body                      text,
   user_id                   int,
-  reviewed_by               int
+  reviewed_by               int,
+  published_by              int
 );
 
 comment on column p.post.user_id is
   E'@references p.user(id)';
 comment on table p.post is
-  E'@foreignKey (reviewed_by) references p.user(id)';
+  E'@foreignKey (reviewed_by) references p.user(id)\n@foreignKey (published_by) references p.user(id)';


### PR DESCRIPTION
Prior to this change, declaring multiple tags on the same table/field
would cause a failure.

This change adds support for multiple `@foreignKey` and
`@references` tags per table/column.